### PR TITLE
keep UI working with the latest ArchivesSpace code

### DIFF
--- a/frontend/views/material_types/_template.html.erb
+++ b/frontend/views/material_types/_template.html.erb
@@ -1,10 +1,8 @@
 <% define_template("material_type", jsonmodel_definition(:material_types)) do |form| %>
   <% material_type_form_field = lambda do |name, value| %>
     <div class="form-group">
-      <div class="col-sm-1 checkbox">
-        <%= form.checkbox name, {:plugin => true}, value %>
-      </div>
-      <%= form.label name, {:plugin => true, :style => "text-align: left;"}, ["col-sm-10"] %>
+      <%= form.checkbox name, {:plugin => true}, value %>
+      <%= form.label name, {:plugin => true, :style => "text-align: left !important;"} %>
     </div>
   <% end %>
 


### PR DESCRIPTION
Preparing for the upcoming ArchivesSpace major release, I tested the plugin with the latest code from the master branch of ArchivesSpace. It seems to work fine except for this small UI fix.

I tested it on Chrome with the latest ArchivesSpace release (v3.5.1) and also the latest code of ArchivesSpace from master branch. 